### PR TITLE
go v2以上版本依赖

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tjfoc/gmsm
+module github.com/tjfoc/gmsm/v2
 
 go 1.14
 


### PR DESCRIPTION
目前发布的v2.0.0版本，不能被go的模块管理引入，需要在module后面加 `v2`才可以引入。